### PR TITLE
Add Google Calendar link to email templates sent out with deadlines

### DIFF
--- a/src/it/java/teammates/it/storage/sqlapi/AccountRequestsDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/AccountRequestsDbIT.java
@@ -11,7 +11,6 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.it.test.BaseTestCaseWithSqlDatabaseAccess;
 import teammates.storage.sqlapi.AccountRequestsDb;
 import teammates.storage.sqlentity.AccountRequest;
-import teammates.test.TestProperties;
 
 /**
  * SUT: {@link AccountRequestsDb}.
@@ -240,9 +239,6 @@ public class AccountRequestsDbIT extends BaseTestCaseWithSqlDatabaseAccess {
 
     @Test
     public void testSqlInjectionSearchAccountRequestsInWholeSystem() throws Exception {
-        if (!TestProperties.isSearchServiceActive()) {
-            return;
-        }
         ______TS("SQL Injection test in searchAccountRequestsInWholeSystem");
 
         AccountRequest accountRequest =

--- a/src/it/java/teammates/it/storage/sqlapi/AccountRequestsDbIT.java
+++ b/src/it/java/teammates/it/storage/sqlapi/AccountRequestsDbIT.java
@@ -11,6 +11,7 @@ import teammates.common.exception.InvalidParametersException;
 import teammates.it.test.BaseTestCaseWithSqlDatabaseAccess;
 import teammates.storage.sqlapi.AccountRequestsDb;
 import teammates.storage.sqlentity.AccountRequest;
+import teammates.test.TestProperties;
 
 /**
  * SUT: {@link AccountRequestsDb}.
@@ -239,6 +240,9 @@ public class AccountRequestsDbIT extends BaseTestCaseWithSqlDatabaseAccess {
 
     @Test
     public void testSqlInjectionSearchAccountRequestsInWholeSystem() throws Exception {
+        if (!TestProperties.isSearchServiceActive()) {
+            return;
+        }
         ______TS("SQL Injection test in searchAccountRequestsInWholeSystem");
 
         AccountRequest accountRequest =

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -1,5 +1,9 @@
 package teammates.common.util;
 
+import com.google.type.DateTime;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -162,4 +166,35 @@ public final class TimeHelper {
         }
     }
 
+    /**
+     * Generates a Google Calendar link with the given time, title, optional description, and time zone.
+     * @param instant The start time of the event.
+     * @param timeZone The ID of the time zone to be used for time formatting.
+     * @param title The title of the event.
+     * @param description The optional description of the event. Can be null or empty.
+     * @return The URL to create a Google Calendar event.
+     */
+    public static String getGoogleCalendarLink(Instant instant, String timeZone, String title, String description) {
+        if (instant == null || timeZone == null || title == null) {
+            return "";
+        }
+
+        ZonedDateTime zonedDateTime = instant.atZone(ZoneId.of(timeZone));
+
+        // Define formatter with the Google Calendar expected format
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'")
+                .withZone(ZoneId.of(timeZone));
+
+        String startTime = formatter.format(zonedDateTime);
+        String endTime = formatter.format(zonedDateTime);
+
+        // URL encode title and optionally description to ensure special characters are handled properly
+        String encodedTitle = URLEncoder.encode(title, StandardCharsets.UTF_8);
+        String encodedDescription = (description != null) ? URLEncoder.encode(description, StandardCharsets.UTF_8) : "";
+
+        // Construct the Google Calendar URL
+        return String.format(
+                "https://www.google.com/calendar/render?action=TEMPLATE&text=%s&details=%s&dates=%s/%s",
+                encodedTitle, encodedDescription, startTime, endTime);
+    }
 }

--- a/src/main/java/teammates/common/util/TimeHelper.java
+++ b/src/main/java/teammates/common/util/TimeHelper.java
@@ -1,7 +1,5 @@
 package teammates.common.util;
 
-import com.google.type.DateTime;
-
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -179,10 +179,7 @@ public final class EmailGenerator {
                 "${sessionInstructions}", session.getInstructionsString(),
                 "${startTime}", SanitizationHelper.sanitizeForHtml(
                         TimeHelper.formatInstant(startTime, session.getTimeZone(), DATETIME_DISPLAY_FORMAT)),
-                "${additionalNotes}", additionalNotes,
-                "${googleCalendarLink}", TimeHelper.getGoogleCalendarLink(endTime,
-                        session.getTimeZone(), FEEDBACK_DEADLINE_REMINDER_TITLE,
-                        SanitizationHelper.sanitizeForHtml(session.getFeedbackSessionName())));
+                "${additionalNotes}", additionalNotes);
 
         EmailWrapper email = getEmptyEmailAddressedToEmail(coOwner.getEmail());
         email.setType(emailType);

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -693,7 +693,11 @@ public final class EmailGenerator {
                 .replace("${oldEndTime}", SanitizationHelper.sanitizeForHtml(
                         TimeHelper.formatInstant(oldEndTimeFormatted, session.getTimeZone(), DATETIME_DISPLAY_FORMAT)))
                 .replace("${newEndTime}", SanitizationHelper.sanitizeForHtml(
-                        TimeHelper.formatInstant(newEndTimeFormatted, session.getTimeZone(), DATETIME_DISPLAY_FORMAT)));
+                        TimeHelper.formatInstant(newEndTimeFormatted, session.getTimeZone(),
+                                DATETIME_DISPLAY_FORMAT))).replace("${googleCalendarLink}",
+                        TimeHelper.getGoogleCalendarLink(newEndTimeFormatted, session.getTimeZone(),
+                                FEEDBACK_DEADLINE_REMINDER_TITLE,
+                                SanitizationHelper.sanitizeForHtml(session.getFeedbackSessionName())));
         String feedbackAction = FEEDBACK_ACTION_SUBMIT_EDIT_OR_VIEW;
 
         if (isInstructor) {

--- a/src/main/java/teammates/logic/api/EmailGenerator.java
+++ b/src/main/java/teammates/logic/api/EmailGenerator.java
@@ -56,6 +56,7 @@ public final class EmailGenerator {
     private static final String DATETIME_DISPLAY_FORMAT = "EEE, dd MMM yyyy, hh:mm a z";
 
     private static final long SESSION_LINK_RECOVERY_DURATION_IN_DAYS = 90;
+    private static final String FEEDBACK_DEADLINE_REMINDER_TITLE = "Feedback Session Deadline";
 
     private static final EmailGenerator instance = new EmailGenerator();
 
@@ -178,7 +179,10 @@ public final class EmailGenerator {
                 "${sessionInstructions}", session.getInstructionsString(),
                 "${startTime}", SanitizationHelper.sanitizeForHtml(
                         TimeHelper.formatInstant(startTime, session.getTimeZone(), DATETIME_DISPLAY_FORMAT)),
-                "${additionalNotes}", additionalNotes);
+                "${additionalNotes}", additionalNotes,
+                "${googleCalendarLink}", TimeHelper.getGoogleCalendarLink(endTime,
+                        session.getTimeZone(), FEEDBACK_DEADLINE_REMINDER_TITLE,
+                        SanitizationHelper.sanitizeForHtml(session.getFeedbackSessionName())));
 
         EmailWrapper email = getEmptyEmailAddressedToEmail(coOwner.getEmail());
         email.setType(emailType);
@@ -317,7 +321,10 @@ public final class EmailGenerator {
                     "${deadline}", TimeHelper.formatInstant(endTime, fsa.getTimeZone(), DATETIME_DISPLAY_FORMAT)
                             + (fsa.isClosed() ? " (Passed)" : ""),
                     "${submitUrl}", submitUrlHtml,
-                    "${reportUrl}", reportUrlHtml));
+                    "${reportUrl}", reportUrlHtml,
+                    "${googleCalendarLink}", TimeHelper.getGoogleCalendarLink(endTime,
+                            fsa.getTimeZone(), FEEDBACK_DEADLINE_REMINDER_TITLE,
+                            fsa.getFeedbackSessionName())));
         }
 
         if (linksFragmentValue.length() == 0) {
@@ -761,7 +768,10 @@ public final class EmailGenerator {
                 "${submitUrl}", submitUrl,
                 "${reportUrl}", reportUrl,
                 "${feedbackAction}", feedbackAction,
-                "${additionalContactInformation}", additionalContactInformation);
+                "${additionalContactInformation}", additionalContactInformation,
+                "${googleCalendarLink}", TimeHelper.getGoogleCalendarLink(endTime,
+                        session.getTimeZone(), FEEDBACK_DEADLINE_REMINDER_TITLE,
+                        SanitizationHelper.sanitizeForHtml(session.getFeedbackSessionName())));
 
         EmailWrapper email = getEmptyEmailAddressedToEmail(student.getEmail());
         email.setType(type);
@@ -802,7 +812,10 @@ public final class EmailGenerator {
                 "${submitUrl}", submitUrl,
                 "${reportUrl}", reportUrl,
                 "${feedbackAction}", feedbackAction,
-                "${additionalContactInformation}", additionalContactInformation);
+                "${additionalContactInformation}", additionalContactInformation,
+                "${googleCalendarLink}", TimeHelper.getGoogleCalendarLink(endTime,
+                        session.getTimeZone(), FEEDBACK_DEADLINE_REMINDER_TITLE,
+                        SanitizationHelper.sanitizeForHtml(session.getFeedbackSessionName())));
 
         EmailWrapper email = getEmptyEmailAddressedToEmail(instructor.getEmail());
         email.setType(type);
@@ -828,7 +841,10 @@ public final class EmailGenerator {
                 "${submitUrl}", "{in the actual email sent to the students, this will be the unique link}",
                 "${reportUrl}", "{in the actual email sent to the students, this will be the unique link}",
                 "${feedbackAction}", feedbackAction,
-                "${additionalContactInformation}", additionalContactInformation);
+                "${additionalContactInformation}", additionalContactInformation,
+                "${googleCalendarLink}", TimeHelper.getGoogleCalendarLink(endTime,
+                        session.getTimeZone(), FEEDBACK_DEADLINE_REMINDER_TITLE,
+                        SanitizationHelper.sanitizeForHtml(session.getFeedbackSessionName())));
 
         EmailWrapper email = getEmptyEmailAddressedToEmail(instructor.getEmail());
         email.setType(type);

--- a/src/main/resources/ownerEmailTemplate-feedbackSession.html
+++ b/src/main/resources/ownerEmailTemplate-feedbackSession.html
@@ -61,8 +61,7 @@
     </tr>
   </table>
 </div>
-<br>
-<br>
+
 ${additionalNotes}
 
 <p>

--- a/src/main/resources/ownerEmailTemplate-feedbackSession.html
+++ b/src/main/resources/ownerEmailTemplate-feedbackSession.html
@@ -61,7 +61,11 @@
     </tr>
   </table>
 </div>
-
+<br>
+<br>
+To add this deadline to your Google Calendar, <a href="${googleCalendarLink}">click here</a>.
+<br>
+<br>
 ${additionalNotes}
 
 <p>

--- a/src/main/resources/ownerEmailTemplate-feedbackSession.html
+++ b/src/main/resources/ownerEmailTemplate-feedbackSession.html
@@ -63,9 +63,6 @@
 </div>
 <br>
 <br>
-To add this deadline to your Google Calendar, <a href="${googleCalendarLink}">click here</a>.
-<br>
-<br>
 ${additionalNotes}
 
 <p>

--- a/src/main/resources/userEmailTemplate-deadlineExtension.html
+++ b/src/main/resources/userEmailTemplate-deadlineExtension.html
@@ -73,6 +73,9 @@ ${instructorPreamble}
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+      To add this deadline to your Google Calendar, <a href="${googleCalendarLink}">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/main/resources/userEmailTemplate-feedbackSession.html
+++ b/src/main/resources/userEmailTemplate-feedbackSession.html
@@ -62,6 +62,9 @@ ${instructorPreamble}
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+      To add this deadline to your Google Calendar, <a href="${googleCalendarLink}">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/main/resources/userEmailTemplate-feedbackSessionOpening.html
+++ b/src/main/resources/userEmailTemplate-feedbackSessionOpening.html
@@ -62,6 +62,9 @@ ${instructorPreamble}
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+    To add this deadline to your Google Calendar, <a href="${googleCalendarLink}">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/main/resources/userEmailTemplate-feedbackSessionOpening.html
+++ b/src/main/resources/userEmailTemplate-feedbackSessionOpening.html
@@ -63,7 +63,7 @@ ${instructorPreamble}
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
     <li>
-    To add this deadline to your Google Calendar, <a href="${googleCalendarLink}">click here</a>.
+      To add this deadline to your Google Calendar, <a href="${googleCalendarLink}">click here</a>.
     </li>
   </ul>
 </p>

--- a/src/main/resources/userEmailTemplateFragment-feedbackSessionResendAllLinks.html
+++ b/src/main/resources/userEmailTemplateFragment-feedbackSessionResendAllLinks.html
@@ -11,3 +11,6 @@ After submitting, you are encouraged to download the proof of submission, which 
 To view the responses for this session, please go to this Web address: ${reportUrl}
 <br>
 <br>
+To add this deadline to your Google Calendar, <a href="${googleCalendarLink}">click here</a>.
+<br>
+<br>

--- a/src/test/resources/emails/deadlineExtensionGivenInstructor.html
+++ b/src/test/resources/emails/deadlineExtensionGivenInstructor.html
@@ -74,7 +74,7 @@
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
     <li>
-      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270501T010000Z/20270501T010000Z">click here</a>.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/deadlineExtensionGivenInstructor.html
+++ b/src/test/resources/emails/deadlineExtensionGivenInstructor.html
@@ -73,6 +73,9 @@
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/deadlineExtensionGivenInstructor.html
+++ b/src/test/resources/emails/deadlineExtensionGivenInstructor.html
@@ -65,7 +65,7 @@
   <ul>
     <li>
       <strong>To submit, edit or view your feedback for the above session, please go to this Web address: </strong>
-      <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+      <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
     </li>
     <li>
       The above link is unique to you. Please do not share it with others.

--- a/src/test/resources/emails/deadlineExtensionGivenInstructor.html
+++ b/src/test/resources/emails/deadlineExtensionGivenInstructor.html
@@ -65,7 +65,7 @@
   <ul>
     <li>
       <strong>To submit, edit or view your feedback for the above session, please go to this Web address: </strong>
-      <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+      <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
     </li>
     <li>
       The above link is unique to you. Please do not share it with others.

--- a/src/test/resources/emails/deadlineExtensionGivenStudent.html
+++ b/src/test/resources/emails/deadlineExtensionGivenStudent.html
@@ -74,7 +74,7 @@
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
     <li>
-      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270501T010000Z/20270501T010000Z">click here</a>.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/deadlineExtensionGivenStudent.html
+++ b/src/test/resources/emails/deadlineExtensionGivenStudent.html
@@ -73,6 +73,9 @@
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/deadlineExtensionRevokedInstructor.html
+++ b/src/test/resources/emails/deadlineExtensionRevokedInstructor.html
@@ -73,6 +73,9 @@
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/deadlineExtensionRevokedInstructor.html
+++ b/src/test/resources/emails/deadlineExtensionRevokedInstructor.html
@@ -65,7 +65,7 @@
   <ul>
     <li>
       <strong>To submit, edit or view your feedback for the above session, please go to this Web address: </strong>
-      <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+      <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
     </li>
     <li>
       The above link is unique to you. Please do not share it with others.

--- a/src/test/resources/emails/deadlineExtensionRevokedInstructor.html
+++ b/src/test/resources/emails/deadlineExtensionRevokedInstructor.html
@@ -65,7 +65,7 @@
   <ul>
     <li>
       <strong>To submit, edit or view your feedback for the above session, please go to this Web address: </strong>
-      <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+      <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
     </li>
     <li>
       The above link is unique to you. Please do not share it with others.

--- a/src/test/resources/emails/deadlineExtensionRevokedStudent.html
+++ b/src/test/resources/emails/deadlineExtensionRevokedStudent.html
@@ -73,6 +73,9 @@
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/deadlineExtensionUpdatedInstructor.html
+++ b/src/test/resources/emails/deadlineExtensionUpdatedInstructor.html
@@ -74,7 +74,7 @@
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
     <li>
-      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270501T010000Z/20270501T010000Z">click here</a>.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/deadlineExtensionUpdatedInstructor.html
+++ b/src/test/resources/emails/deadlineExtensionUpdatedInstructor.html
@@ -73,6 +73,9 @@
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/deadlineExtensionUpdatedInstructor.html
+++ b/src/test/resources/emails/deadlineExtensionUpdatedInstructor.html
@@ -65,7 +65,7 @@
   <ul>
     <li>
       <strong>To submit, edit or view your feedback for the above session, please go to this Web address: </strong>
-      <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+      <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
     </li>
     <li>
       The above link is unique to you. Please do not share it with others.

--- a/src/test/resources/emails/deadlineExtensionUpdatedInstructor.html
+++ b/src/test/resources/emails/deadlineExtensionUpdatedInstructor.html
@@ -65,7 +65,7 @@
   <ul>
     <li>
       <strong>To submit, edit or view your feedback for the above session, please go to this Web address: </strong>
-      <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+      <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
     </li>
     <li>
       The above link is unique to you. Please do not share it with others.

--- a/src/test/resources/emails/deadlineExtensionUpdatedStudent.html
+++ b/src/test/resources/emails/deadlineExtensionUpdatedStudent.html
@@ -73,6 +73,9 @@
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270501T010000Z/20270501T010000Z">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionClosingEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionClosingEmailCopyToInstructor.html
@@ -66,6 +66,9 @@
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionClosingEmailForInstructor.html
+++ b/src/test/resources/emails/sessionClosingEmailForInstructor.html
@@ -63,7 +63,7 @@
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
     <li>
-      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270501T010000Z/20270501T010000Z">click here</a>.
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/sessionClosingEmailForInstructor.html
+++ b/src/test/resources/emails/sessionClosingEmailForInstructor.html
@@ -62,6 +62,9 @@
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270501T010000Z/20270501T010000Z">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionClosingEmailForInstructorWithExtension.html
+++ b/src/test/resources/emails/sessionClosingEmailForInstructorWithExtension.html
@@ -62,6 +62,9 @@
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270501T235900Z/20270501T235900Z">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionClosingEmailForStudent.html
+++ b/src/test/resources/emails/sessionClosingEmailForStudent.html
@@ -62,6 +62,9 @@
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionClosingEmailForStudentWithExtension.html
+++ b/src/test/resources/emails/sessionClosingEmailForStudentWithExtension.html
@@ -62,6 +62,9 @@
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270501T010000Z/20270501T010000Z">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionClosingEmailTestingSanitizationCopyToInstructor.html
+++ b/src/test/resources/emails/sessionClosingEmailTestingSanitizationCopyToInstructor.html
@@ -66,6 +66,9 @@
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Normal+feedback+session+name&dates=20270430T235900Z/20270430T235900Z">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionClosingEmailTestingSanitizationForStudent.html
+++ b/src/test/resources/emails/sessionClosingEmailTestingSanitizationForStudent.html
@@ -62,6 +62,9 @@
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionClosingEmailTestingSanitizationForStudent.html
+++ b/src/test/resources/emails/sessionClosingEmailTestingSanitizationForStudent.html
@@ -63,7 +63,7 @@
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
     <li>
-      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Normal+feedback+session+name&dates=20270430T235900Z/20270430T235900Z">click here</a>.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/sessionOpeningEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionOpeningEmailCopyToInstructor.html
@@ -66,6 +66,9 @@
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionOpeningEmailForInstructor.html
+++ b/src/test/resources/emails/sessionOpeningEmailForInstructor.html
@@ -62,6 +62,9 @@
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionOpeningEmailForStudent.html
+++ b/src/test/resources/emails/sessionOpeningEmailForStudent.html
@@ -62,6 +62,9 @@
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionOpeningEmailTestingSanitizationCopyToInstructor.html
+++ b/src/test/resources/emails/sessionOpeningEmailTestingSanitizationCopyToInstructor.html
@@ -66,6 +66,9 @@
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+      To add this deadline to your Google Calendar, <a href="${googleCalendarLink}">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionOpeningEmailTestingSanitizationCopyToInstructor.html
+++ b/src/test/resources/emails/sessionOpeningEmailTestingSanitizationCopyToInstructor.html
@@ -67,7 +67,7 @@
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
     <li>
-      To add this deadline to your Google Calendar, <a href="${googleCalendarLink}">click here</a>.
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Normal+feedback+session+name&dates=20270430T235900Z/20270430T235900Z">click here</a>.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/sessionOpeningEmailTestingSanitizationForStudent.html
+++ b/src/test/resources/emails/sessionOpeningEmailTestingSanitizationForStudent.html
@@ -62,6 +62,9 @@
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Normal+feedback+session+name&dates=20270430T235900Z/20270430T235900Z">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionReminderEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionReminderEmailCopyToInstructor.html
@@ -66,6 +66,9 @@
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+      To add this deadline to your Google Calendar, <a href="${googleCalendarLink}">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionReminderEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionReminderEmailCopyToInstructor.html
@@ -67,7 +67,7 @@
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
     <li>
-      To add this deadline to your Google Calendar, <a href="${googleCalendarLink}">click here</a>.
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/sessionReminderEmailForInstructor.html
+++ b/src/test/resources/emails/sessionReminderEmailForInstructor.html
@@ -62,6 +62,9 @@
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/sessionReminderEmailForStudent.html
+++ b/src/test/resources/emails/sessionReminderEmailForStudent.html
@@ -62,6 +62,9 @@
     <li>
       After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
     </li>
+    <li>
+      To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
+    </li>
   </ul>
 </p>
 

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedInstructor.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedInstructor.html
@@ -5,57 +5,67 @@
   Here are your new links for this course.
 </p>
 
-
-
 <p>
   Below are the new links to the feedback sessions of the course.
   <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Closed Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Sat, 01 Jun 2013, 11:59 PM SAST (Passed)
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
-To view the responses for this session, please go to this Web address: <a href="${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
+To view the responses for this session, please go to this Web address: <a href="http://localhost:4200/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
+<br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Closed+Session&dates=20130601T235900Z/20130601T235900Z">click here</a>.
 <br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> First feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Fri, 30 Apr 2027, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
+<br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
 <br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Grace Period Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
+<br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Grace+Period+Session&dates=20260428T235900Z/20260428T235900Z">click here</a>.
 <br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Second feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
+<br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Second+feedback+session&dates=20260428T235900Z/20260428T235900Z">click here</a>.
 <br>
 <br>
 </p>
@@ -70,7 +80,7 @@ To view the responses for this session, please go to this Web address: (Feedback
     </li>
     <li>
       <strong>Technical help regarding TEAMMATES</strong> (e.g. submission link is not working):
-      Email TEAMMATES support team at ${support.email}.
+      Email TEAMMATES support team at app_admin@gmail.com.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedInstructor.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedInstructor.html
@@ -13,13 +13,13 @@
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Closed Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Sat, 01 Jun 2013, 11:59 PM SAST (Passed)
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
-To view the responses for this session, please go to this Web address: <a href="http://localhost:4200/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
+To view the responses for this session, please go to this Web address: <a href="http://${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Closed+Session&dates=20130601T235900Z/20130601T235900Z">click here</a>.
@@ -28,7 +28,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> First feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Fri, 30 Apr 2027, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
@@ -43,7 +43,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Grace Period Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
@@ -58,7 +58,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Second feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedInstructor.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedInstructor.html
@@ -5,6 +5,8 @@
   Here are your new links for this course.
 </p>
 
+
+
 <p>
   Below are the new links to the feedback sessions of the course.
   <br><br>

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedInstructor.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedInstructor.html
@@ -13,13 +13,13 @@
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Closed Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Sat, 01 Jun 2013, 11:59 PM SAST (Passed)
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
-To view the responses for this session, please go to this Web address: <a href="http://${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
+To view the responses for this session, please go to this Web address: <a href="http://localhost:4200/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Closed+Session&dates=20130601T235900Z/20130601T235900Z">click here</a>.
@@ -28,7 +28,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> First feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Fri, 30 Apr 2027, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
@@ -43,7 +43,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Grace Period Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
@@ -58,7 +58,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Second feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedStudent.html
@@ -21,6 +21,9 @@ After submitting, you are encouraged to download the proof of submission, which 
 <br>
 To view the responses for this session, please go to this Web address: <a href="${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
 <br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Closed+Session&dates=20130601T235900Z/20130601T235900Z">click here</a>.
+<br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> First feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Fri, 30 Apr 2027, 11:59 PM SAST
@@ -33,6 +36,9 @@ After submitting, you are encouraged to download the proof of submission, which 
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
 <br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
+<br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Grace Period Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
@@ -44,6 +50,9 @@ After submitting, you are encouraged to download the proof of submission, which 
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
+<br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Grace+Period+Session&dates=20260428T235900Z/20260428T235900Z">click here</a>.
 <br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Second feedback session
@@ -58,8 +67,10 @@ After submitting, you are encouraged to download the proof of submission, which 
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
 <br>
 <br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Second+feedback+session&dates=20260428T235900Z/20260428T235900Z">click here</a>.
+<br>
+<br>
 </p>
-
 <p>
   <ul>
     <li>

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedStudent.html
@@ -85,4 +85,3 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
   Regards,
   <br>TEAMMATES Team.
 </p>
-

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedStudent.html
@@ -1,8 +1,12 @@
 <p>Hello student1 In Course1&lt;&#x2f;td&gt;&lt;&#x2f;div&gt;&#39;&quot;,</p>
+
 <p>
   TEAMMATES has updated your links for the course [Course name: Typical Course 1 with 2 Evals] [Course ID: idOfTypicalCourse1].
   Here are your new links for this course.
 </p>
+
+
+
 <p>
   Below are the new links to the feedback sessions of the course.
   <br><br>
@@ -67,6 +71,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
 <br>
 <br>
 </p>
+
 <p>
   <ul>
     <li>
@@ -81,6 +86,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
     </li>
   </ul>
 </p>
+
 <p>
   Regards,
   <br>TEAMMATES Team.

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedStudent.html
@@ -13,13 +13,13 @@
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Closed Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Sat, 01 Jun 2013, 11:59 PM SAST (Passed)
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
-To view the responses for this session, please go to this Web address: <a href="http://localhost:4200/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">http://localhost:4200/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
+To view the responses for this session, please go to this Web address: <a href="http://${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">http://${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
 <br>
 <br>
 To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Closed+Session&dates=20130601T235900Z/20130601T235900Z">click here</a>.
@@ -28,7 +28,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> First feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Fri, 30 Apr 2027, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
@@ -43,7 +43,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Grace Period Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
@@ -58,7 +58,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Second feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedStudent.html
@@ -1,25 +1,21 @@
 <p>Hello student1 In Course1&lt;&#x2f;td&gt;&lt;&#x2f;div&gt;&#39;&quot;,</p>
-
 <p>
   TEAMMATES has updated your links for the course [Course name: Typical Course 1 with 2 Evals] [Course ID: idOfTypicalCourse1].
   Here are your new links for this course.
 </p>
-
-
-
 <p>
   Below are the new links to the feedback sessions of the course.
   <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Closed Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Sat, 01 Jun 2013, 11:59 PM SAST (Passed)
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
-To view the responses for this session, please go to this Web address: <a href="${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
+To view the responses for this session, please go to this Web address: <a href="http://localhost:4200/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">http://localhost:4200/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
 <br>
 <br>
 To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Closed+Session&dates=20130601T235900Z/20130601T235900Z">click here</a>.
@@ -28,7 +24,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> First feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Fri, 30 Apr 2027, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
@@ -43,7 +39,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Grace Period Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
@@ -58,7 +54,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Second feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
@@ -81,12 +77,12 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
     </li>
     <li>
       <strong>Technical help regarding TEAMMATES</strong> (e.g. submission link is not working):
-      Email TEAMMATES support team at ${support.email}.
+      Email TEAMMATES support team at app_admin@gmail.com.
     </li>
   </ul>
 </p>
-
 <p>
   Regards,
   <br>TEAMMATES Team.
 </p>
+

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedStudent.html
@@ -13,13 +13,13 @@
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Closed Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Sat, 01 Jun 2013, 11:59 PM SAST (Passed)
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
-To view the responses for this session, please go to this Web address: <a href="http://${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">http://${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
+To view the responses for this session, please go to this Web address: <a href="http://localhost:4200/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">http://localhost:4200/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
 <br>
 <br>
 To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Closed+Session&dates=20130601T235900Z/20130601T235900Z">click here</a>.
@@ -28,7 +28,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> First feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Fri, 30 Apr 2027, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
@@ -43,7 +43,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Grace Period Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
@@ -58,7 +58,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Second feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedUnregisteredInstructor.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedUnregisteredInstructor.html
@@ -7,7 +7,7 @@
 
 <p>
   <strong>To "join" the course, please go to this Web address: </strong>
-  <a href="http://localhost:4200/web/join?key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/join?key=${regkey.enc}&entitytype=instructor</a>
+  <a href="http://${app.url}/web/join?key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/join?key=${regkey.enc}&entitytype=instructor</a>
   <ul>
     <li>
       If prompted to log in, use your Google account to log in.
@@ -31,13 +31,13 @@
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Closed Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Sat, 01 Jun 2013, 11:59 PM SAST (Passed)
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
-To view the responses for this session, please go to this Web address: <a href="http://localhost:4200/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
+To view the responses for this session, please go to this Web address: <a href="http://${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Closed+Session&dates=20130601T235900Z/20130601T235900Z">click here</a>.
@@ -46,7 +46,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> First feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Fri, 30 Apr 2027, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
@@ -61,7 +61,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Grace Period Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
@@ -76,7 +76,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Second feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedUnregisteredInstructor.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedUnregisteredInstructor.html
@@ -7,7 +7,7 @@
 
 <p>
   <strong>To "join" the course, please go to this Web address: </strong>
-  <a href="${app.url}/web/join?key=${regkey.enc}&entitytype=instructor">${app.url}/web/join?key=${regkey.enc}&entitytype=instructor</a>
+  <a href="http://localhost:4200/web/join?key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/join?key=${regkey.enc}&entitytype=instructor</a>
   <ul>
     <li>
       If prompted to log in, use your Google account to log in.
@@ -21,7 +21,7 @@
 
 <p>
   <strong>
-    If you did not request for this account reset before, please contact our TEAMMATES support team at ${support.email}.
+    If you did not request for this account reset before, please contact our TEAMMATES support team at app_admin@gmail.com.
   </strong>
 </p>
 
@@ -31,49 +31,61 @@
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Closed Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Sat, 01 Jun 2013, 11:59 PM SAST (Passed)
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
-To view the responses for this session, please go to this Web address: <a href="${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
+To view the responses for this session, please go to this Web address: <a href="http://localhost:4200/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
+<br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Closed+Session&dates=20130601T235900Z/20130601T235900Z">click here</a>.
 <br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> First feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Fri, 30 Apr 2027, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
+<br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
 <br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Grace Period Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
+<br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Grace+Period+Session&dates=20260428T235900Z/20260428T235900Z">click here</a>.
 <br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Second feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
+<br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Second+feedback+session&dates=20260428T235900Z/20260428T235900Z">click here</a>.
 <br>
 <br>
 </p>
@@ -88,7 +100,7 @@ To view the responses for this session, please go to this Web address: (Feedback
     </li>
     <li>
       <strong>Technical help regarding TEAMMATES</strong> (e.g. submission link is not working):
-      Email TEAMMATES support team at ${support.email}.
+      Email TEAMMATES support team at app_admin@gmail.com.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedUnregisteredInstructor.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedUnregisteredInstructor.html
@@ -7,7 +7,7 @@
 
 <p>
   <strong>To "join" the course, please go to this Web address: </strong>
-  <a href="http://${app.url}/web/join?key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/join?key=${regkey.enc}&entitytype=instructor</a>
+  <a href="http://localhost:4200/web/join?key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/join?key=${regkey.enc}&entitytype=instructor</a>
   <ul>
     <li>
       If prompted to log in, use your Google account to log in.
@@ -31,13 +31,13 @@
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Closed Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Sat, 01 Jun 2013, 11:59 PM SAST (Passed)
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
-To view the responses for this session, please go to this Web address: <a href="http://${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
+To view the responses for this session, please go to this Web address: <a href="http://localhost:4200/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Closed+Session&dates=20130601T235900Z/20130601T235900Z">click here</a>.
@@ -46,7 +46,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> First feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Fri, 30 Apr 2027, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
@@ -61,7 +61,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Grace Period Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
@@ -76,7 +76,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Second feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://localhost:4200/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedUnregisteredInstructor.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedUnregisteredInstructor.html
@@ -7,7 +7,7 @@
 
 <p>
   <strong>To "join" the course, please go to this Web address: </strong>
-  <a href="${app.url}/web/join?key=${regkey.enc}&entitytype=instructor">${app.url}/web/join?key=${regkey.enc}&entitytype=instructor</a>
+  <a href="http://${app.url}/web/join?key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/join?key=${regkey.enc}&entitytype=instructor</a>
   <ul>
     <li>
       If prompted to log in, use your Google account to log in.
@@ -21,7 +21,7 @@
 
 <p>
   <strong>
-    If you did not request for this account reset before, please contact our TEAMMATES support team at ${support.email}.
+    If you did not request for this account reset before, please contact our TEAMMATES support team at app_admin@gmail.com.
   </strong>
 </p>
 
@@ -31,49 +31,61 @@
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Closed Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Sat, 01 Jun 2013, 11:59 PM SAST (Passed)
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
-To view the responses for this session, please go to this Web address: <a href="${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
+To view the responses for this session, please go to this Web address: <a href="http://${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
+<br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Closed+Session&dates=20130601T235900Z/20130601T235900Z">click here</a>.
 <br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> First feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Fri, 30 Apr 2027, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
+<br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
 <br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Grace Period Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
+<br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Grace+Period+Session&dates=20260428T235900Z/20260428T235900Z">click here</a>.
 <br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Second feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
+<br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Second+feedback+session&dates=20260428T235900Z/20260428T235900Z">click here</a>.
 <br>
 <br>
 </p>
@@ -88,7 +100,7 @@ To view the responses for this session, please go to this Web address: (Feedback
     </li>
     <li>
       <strong>Technical help regarding TEAMMATES</strong> (e.g. submission link is not working):
-      Email TEAMMATES support team at ${support.email}.
+      Email TEAMMATES support team at app_admin@gmail.com.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedUnregisteredInstructor.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedUnregisteredInstructor.html
@@ -7,7 +7,7 @@
 
 <p>
   <strong>To "join" the course, please go to this Web address: </strong>
-  <a href="http://${app.url}/web/join?key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/join?key=${regkey.enc}&entitytype=instructor</a>
+  <a href="${app.url}/web/join?key=${regkey.enc}&entitytype=instructor">${app.url}/web/join?key=${regkey.enc}&entitytype=instructor</a>
   <ul>
     <li>
       If prompted to log in, use your Google account to log in.
@@ -21,7 +21,7 @@
 
 <p>
   <strong>
-    If you did not request for this account reset before, please contact our TEAMMATES support team at app_admin@gmail.com.
+    If you did not request for this account reset before, please contact our TEAMMATES support team at ${support.email}.
   </strong>
 </p>
 
@@ -31,61 +31,49 @@
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Closed Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Sat, 01 Jun 2013, 11:59 PM SAST (Passed)
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
-To view the responses for this session, please go to this Web address: <a href="http://${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
-<br>
-<br>
-To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Closed+Session&dates=20130601T235900Z/20130601T235900Z">click here</a>.
+To view the responses for this session, please go to this Web address: <a href="${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> First feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Fri, 30 Apr 2027, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=First%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
-<br>
-<br>
-To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
 <br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Grace Period Session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Grace%20Period%20Session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
-<br>
-<br>
-To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Grace+Period+Session&dates=20260428T235900Z/20260428T235900Z">click here</a>.
 <br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Second feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
 <br>
-To view/submit feedback for the above session, please go to this Web address: <a href="http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor">http://${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
+To view/submit feedback for the above session, please go to this Web address: <a href="${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor">${app.url}/web/sessions/submission?courseid=idOfTypicalCourse1&fsname=Second%20feedback%20session&key=${regkey.enc}&entitytype=instructor</a>
 <br>
 <br>
 After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
-<br>
-<br>
-To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Second+feedback+session&dates=20260428T235900Z/20260428T235900Z">click here</a>.
 <br>
 <br>
 </p>
@@ -100,7 +88,7 @@ To add this deadline to your Google Calendar, <a href="https://www.google.com/ca
     </li>
     <li>
       <strong>Technical help regarding TEAMMATES</strong> (e.g. submission link is not working):
-      Email TEAMMATES support team at app_admin@gmail.com.
+      Email TEAMMATES support team at ${support.email}.
     </li>
   </ul>
 </p>

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedUnregisteredStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForRegeneratedUnregisteredStudent.html
@@ -49,6 +49,9 @@ After submitting, you are encouraged to download the proof of submission, which 
 <br>
 To view the responses for this session, please go to this Web address: <a href="${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
 <br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Closed+Session&dates=20130601T235900Z/20130601T235900Z">click here</a>.
+<br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> First feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Fri, 30 Apr 2027, 11:59 PM SAST
@@ -60,6 +63,9 @@ After submitting, you are encouraged to download the proof of submission, which 
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
+<br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
 <br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Grace Period Session
@@ -73,6 +79,9 @@ After submitting, you are encouraged to download the proof of submission, which 
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
 <br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Grace+Period+Session&dates=20260428T235900Z/20260428T235900Z">click here</a>.
+<br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Second feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
@@ -84,6 +93,9 @@ After submitting, you are encouraged to download the proof of submission, which 
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
+<br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Second+feedback+session&dates=20260428T235900Z/20260428T235900Z">click here</a>.
 <br>
 <br>
 </p>

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForStudent.html
@@ -21,6 +21,9 @@ After submitting, you are encouraged to download the proof of submission, which 
 <br>
 To view the responses for this session, please go to this Web address: <a href="${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
 <br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Closed+Session&dates=20130601T235900Z/20130601T235900Z">click here</a>.
+<br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> First feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Fri, 30 Apr 2027, 11:59 PM SAST
@@ -32,6 +35,9 @@ After submitting, you are encouraged to download the proof of submission, which 
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
+<br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
 <br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Grace Period Session
@@ -59,6 +65,9 @@ After submitting, you are encouraged to download the proof of submission, which 
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
+<br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Second+feedback+session&dates=20260428T235900Z/20260428T235900Z">click here</a>.
 <br>
 <br>
 </p>

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForStudent.html
@@ -45,6 +45,9 @@ After submitting, you are encouraged to download the proof of submission, which 
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
 <br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Grace+Period+Session&dates=20260428T235900Z/20260428T235900Z">click here</a>.
+<br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Second feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForUnregisteredStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForUnregisteredStudent.html
@@ -46,6 +46,9 @@ After submitting, you are encouraged to download the proof of submission, which 
 <br>
 To view the responses for this session, please go to this Web address: <a href="${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}">${app.url}/web/sessions/result?courseid=idOfTypicalCourse1&fsname=Closed%20Session&key=${regkey.enc}</a>
 <br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Closed+Session&dates=20130601T235900Z/20130601T235900Z">click here</a>.
+<br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> First feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Fri, 30 Apr 2027, 11:59 PM SAST
@@ -57,6 +60,9 @@ After submitting, you are encouraged to download the proof of submission, which 
 <br>
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
+<br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
 <br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Grace Period Session
@@ -70,6 +76,9 @@ After submitting, you are encouraged to download the proof of submission, which 
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
 <br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Grace+Period+Session&dates=20260428T235900Z/20260428T235900Z">click here</a>.
+<br>
 <br><br>
 <br>&nbsp;&nbsp; <strong>Feedback Session Name:</strong> Second feedback session
 <br>&nbsp;&nbsp; <strong>Deadline:</strong> Tue, 28 Apr 2026, 11:59 PM SAST
@@ -82,9 +91,9 @@ After submitting, you are encouraged to download the proof of submission, which 
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
 <br>
-  <br>
-  To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
-  <br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Second+feedback+session&dates=20260428T235900Z/20260428T235900Z">click here</a>.
+<br>
 <br>
 </p>
 

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForUnregisteredStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailForUnregisteredStudent.html
@@ -82,6 +82,9 @@ After submitting, you are encouraged to download the proof of submission, which 
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
 <br>
+  <br>
+  To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=First+feedback+session&dates=20270430T235900Z/20270430T235900Z">click here</a>.
+  <br>
 <br>
 </p>
 

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailTestingSanitizationForStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailTestingSanitizationForStudent.html
@@ -21,9 +21,9 @@ After submitting, you are encouraged to download the proof of submission, which 
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
 <br>
-  <br>
-  To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Normal+feedback+session+name&dates=20270430T235900Z/20270430T235900Z">click here</a>.
-  <br>
+<br>
+To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Normal+feedback+session+name&dates=20270430T235900Z/20270430T235900Z">click here</a>.
+<br>
 <br>
 </p>
 

--- a/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailTestingSanitizationForStudent.html
+++ b/src/test/resources/emails/summaryOfFeedbackSessionsOfCourseEmailTestingSanitizationForStudent.html
@@ -21,6 +21,9 @@ After submitting, you are encouraged to download the proof of submission, which 
 <br>
 To view the responses for this session, please go to this Web address: (Feedback session is not yet published)
 <br>
+  <br>
+  To add this deadline to your Google Calendar, <a href="https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Normal+feedback+session+name&dates=20270430T235900Z/20270430T235900Z">click here</a>.
+  <br>
 <br>
 </p>
 


### PR DESCRIPTION
This PR adds the ability for recipients of emails with deadlines to easily add deadlines into their Google Calendar by providing them with a link which is embedded in the HTML of the sent email.


I added the method `TimeHelper::getGoogleCalendarLink` to format the deadline, title and description of the relevant task into a Google Calendar link, and configured the email templates to include this link.


Below is one of the new email formats for feedback session reminders:

---

**Subject:** TEAMMATES: Feedback session reminder [Course: Sample Course 101][Feedback Session: Second team feedback session (point-based)]

**From:** TEAMMATES Admin <teammates@comp.nus.edu.sg>  
**Reply-To:** teammates@comp.nus.edu.sg  
**To:** kenurfseet@gmail.com  

Hello Kenneth,

Just a gentle reminder that the following feedback session is still open for submissions, in case you have not submitted yet or wish to update your submission. *No action is required if you have already submitted.*

---

### Course Information

| Attribute                        | Details                                       |
|----------------------------------|-----------------------------------------------|
| **Course**                       | [kenurfseet.gma-demo] Sample Course 101       |
| **Feedback Session Name**        | Second team feedback session (point-based)    |
| **Deadline**                     | Wed, 19 Jun 2024, 11:59 pm SGT                |
| **Session Instructions**         | Please give your feedback based on the following questions. |

---

### Actions

- **To submit, edit or view your feedback for the above session, please go to this Web address:**  
  [http://localhost:4200/web/sessions/submission?courseid=kenurfseet.gma-demo&fsname=Second%20team%20feedback%20session%20%28point-based%29&key=602EB0BF7EF6D0C18ECD025F71D9D6A52053826442B02EEBA4F0521DE07DA84163403753ADC8D81D2EC07D585A8A200916E7BF23F157A59DF582F4B06A95222C&entitytype=instructor](http://localhost:4200/web/sessions/submission?courseid=kenurfseet.gma-demo&fsname=Second%20team%20feedback%20session%20%28point-based%29&key=602EB0BF7EF6D0C18ECD025F71D9D6A52053826442B02EEBA4F0521DE07DA84163403753ADC8D81D2EC07D585A8A200916E7BF23F157A59DF582F4B06A95222C&entityyoungster=educator)  
  *The above link is unique to you. Please do not share it with others.*
- **After submitting, you are encouraged to download the proof of submission, which will contain your latest responses.**
- **To add this deadline to your Google Calendar:** [click here](https://www.google.com/calendar/render?action=TEMPLATE&text=Feedback+Session+Deadline&details=Second+team+feedback+session+%28point-based%29&dates=20240619T235900Z/20240619T235900Z).

---

### Support

- **Requests for deadline extensions, problems regarding instructor data (e.g. wrong permission, misspelled name)** and **other non-technical queries** about the feedback session:  
  Contact the instructors of the course: kenneth (kenurfseet@gmail.com)
- **Technical help regarding TEAMMATES** (e.g. submission link is not working):  
  Email TEAMMATES support team at app_admin@gmail.com.

---

Regards,  
TEAMMATES Team.
