### PR TITLE
[#12872] Warn instructors not to share link with students

### DIFF
--- a/src/main/resources/instructorEmailFragment-instructorCopyPreamble.html
+++ b/src/main/resources/instructorEmailFragment-instructorCopyPreamble.html
@@ -1,5 +1,13 @@
 <p>
   The email below has been sent to students of course: [${courseId}] ${courseName}.
   <br><br>
+  Kindly note that this email simply serves as a preview of how the email will appear to the
+  students, and the link is not the actual link that the students will receive.
+  As such, please do not forward this email to students.
+  We recommend that you make the following announcement (edit content as you see fit) using an alternative means (e.g., your course announcements) to alert students:
+  <hr>
+  The TEAMMATES session ... in course ... is now open.
+  If you did not receive the unique access link via email, and you can't find it in your spam box either, go to ... (info about link recovery page).
+  <hr>
   === Email message as seen by the students ===
 </p>

--- a/src/test/resources/emails/sessionClosingEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionClosingEmailCopyToInstructor.html
@@ -3,6 +3,14 @@
 <p>
   The email below has been sent to students of course: [idOfTypicalCourse1] Typical Course 1 with 2 Evals.
   <br><br>
+  Kindly note that this email simply serves as a preview of how the email will appear to the
+  students, and the link is not the actual link that the students will receive.
+  As such, please do not forward this email to students.
+  We recommend that you make the following announcement (edit content as you see fit) using an alternative means (e.g., your course announcements) to alert students:
+  <hr>
+  The TEAMMATES session ... in course ... is now open.
+  If you did not receive the unique access link via email, and you can't find it in your spam box either, go to ... (info about link recovery page).
+  <hr>
   === Email message as seen by the students ===
 </p>
 

--- a/src/test/resources/emails/sessionClosingEmailTestingSanitizationCopyToInstructor.html
+++ b/src/test/resources/emails/sessionClosingEmailTestingSanitizationCopyToInstructor.html
@@ -3,6 +3,14 @@
 <p>
   The email below has been sent to students of course: [idOfTestingSanitizationCourse] Testing&lt;script&gt; alert(&#39;hi!&#39;); &lt;&#x2f;script&gt;.
   <br><br>
+  Kindly note that this email simply serves as a preview of how the email will appear to the
+  students, and the link is not the actual link that the students will receive.
+  As such, please do not forward this email to students.
+  We recommend that you make the following announcement (edit content as you see fit) using an alternative means (e.g., your course announcements) to alert students:
+  <hr>
+  The TEAMMATES session ... in course ... is now open.
+  If you did not receive the unique access link via email, and you can't find it in your spam box either, go to ... (info about link recovery page).
+  <hr>
   === Email message as seen by the students ===
 </p>
 

--- a/src/test/resources/emails/sessionOpeningEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionOpeningEmailCopyToInstructor.html
@@ -3,6 +3,14 @@
 <p>
   The email below has been sent to students of course: [idOfTypicalCourse1] Typical Course 1 with 2 Evals.
   <br><br>
+  Kindly note that this email simply serves as a preview of how the email will appear to the
+  students, and the link is not the actual link that the students will receive.
+  As such, please do not forward this email to students.
+  We recommend that you make the following announcement (edit content as you see fit) using an alternative means (e.g., your course announcements) to alert students:
+  <hr>
+  The TEAMMATES session ... in course ... is now open.
+  If you did not receive the unique access link via email, and you can't find it in your spam box either, go to ... (info about link recovery page).
+  <hr>
   === Email message as seen by the students ===
 </p>
 

--- a/src/test/resources/emails/sessionOpeningEmailTestingSanitizationCopyToInstructor.html
+++ b/src/test/resources/emails/sessionOpeningEmailTestingSanitizationCopyToInstructor.html
@@ -3,6 +3,14 @@
 <p>
   The email below has been sent to students of course: [idOfTestingSanitizationCourse] Testing&lt;script&gt; alert(&#39;hi!&#39;); &lt;&#x2f;script&gt;.
   <br><br>
+  Kindly note that this email simply serves as a preview of how the email will appear to the
+  students, and the link is not the actual link that the students will receive.
+  As such, please do not forward this email to students.
+  We recommend that you make the following announcement (edit content as you see fit) using an alternative means (e.g., your course announcements) to alert students:
+  <hr>
+  The TEAMMATES session ... in course ... is now open.
+  If you did not receive the unique access link via email, and you can't find it in your spam box either, go to ... (info about link recovery page).
+  <hr>
   === Email message as seen by the students ===
 </p>
 

--- a/src/test/resources/emails/sessionPublishedEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionPublishedEmailCopyToInstructor.html
@@ -3,6 +3,14 @@
 <p>
   The email below has been sent to students of course: [idOfTypicalCourse1] Typical Course 1 with 2 Evals.
   <br><br>
+  Kindly note that this email simply serves as a preview of how the email will appear to the
+  students, and the link is not the actual link that the students will receive.
+  As such, please do not forward this email to students.
+  We recommend that you make the following announcement (edit content as you see fit) using an alternative means (e.g., your course announcements) to alert students:
+  <hr>
+  The TEAMMATES session ... in course ... is now open.
+  If you did not receive the unique access link via email, and you can't find it in your spam box either, go to ... (info about link recovery page).
+  <hr>
   === Email message as seen by the students ===
 </p>
 

--- a/src/test/resources/emails/sessionReminderEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionReminderEmailCopyToInstructor.html
@@ -3,6 +3,14 @@
 <p>
   The email below has been sent to students of course: [idOfTypicalCourse1] Typical Course 1 with 2 Evals.
   <br><br>
+  Kindly note that this email simply serves as a preview of how the email will appear to the
+  students, and the link is not the actual link that the students will receive.
+  As such, please do not forward this email to students.
+  We recommend that you make the following announcement (edit content as you see fit) using an alternative means (e.g., your course announcements) to alert students:
+  <hr>
+  The TEAMMATES session ... in course ... is now open.
+  If you did not receive the unique access link via email, and you can't find it in your spam box either, go to ... (info about link recovery page).
+  <hr>
   === Email message as seen by the students ===
 </p>
 

--- a/src/test/resources/emails/sessionUnpublishedEmailCopyToInstructor.html
+++ b/src/test/resources/emails/sessionUnpublishedEmailCopyToInstructor.html
@@ -3,6 +3,14 @@
 <p>
   The email below has been sent to students of course: [idOfTypicalCourse1] Typical Course 1 with 2 Evals.
   <br><br>
+  Kindly note that this email simply serves as a preview of how the email will appear to the
+  students, and the link is not the actual link that the students will receive.
+  As such, please do not forward this email to students.
+  We recommend that you make the following announcement (edit content as you see fit) using an alternative means (e.g., your course announcements) to alert students:
+  <hr>
+  The TEAMMATES session ... in course ... is now open.
+  If you did not receive the unique access link via email, and you can't find it in your spam box either, go to ... (info about link recovery page).
+  <hr>
   === Email message as seen by the students ===
 </p>
 


### PR DESCRIPTION
Fixes #12872

**Outline of Solution**

I updated `instructorEmailFragment-instructorCopyPreamble.html` with the warning to the instructor and the tip to use the 'Announcements' page to inform their students instead. I also updated the tests for the `copyToInstructor` templates used for testing.
