### PR TITLE
[#12894] Calculate msq totals by student email instead of name

### DIFF
--- a/src/web/app/components/question-types/question-statistics/mcq-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/mcq-question-statistics.component.ts
@@ -60,6 +60,7 @@ export class McqQuestionStatisticsComponent extends McqQuestionStatisticsCalcula
     this.perRecipientColumnsData = [
       { header: 'Team', sortBy: SortBy.MCQ_TEAM },
       { header: 'Recipient Name', sortBy: SortBy.MCQ_RECIPIENT_NAME },
+      { header: 'Recipient Email', sortBy: SortBy.RECIPIENT_EMAIL },
       ...Object.keys(this.weightPerOption).map((key: string) => {
         return {
           header: `${key}[${(this.weightPerOption[key]).toFixed(2)}]`,

--- a/src/web/app/components/question-types/question-statistics/msq-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/msq-question-statistics.component.ts
@@ -60,6 +60,7 @@ export class MsqQuestionStatisticsComponent extends MsqQuestionStatisticsCalcula
     this.perRecipientColumnsData = [
       { header: 'Team', sortBy: SortBy.MSQ_TEAM },
       { header: 'Recipient Name', sortBy: SortBy.MSQ_RECIPIENT_NAME },
+      { header: 'Recipient Email', sortBy: SortBy.RECIPIENT_EMAIL },
       ...Object.keys(this.weightPerOption).map((key: string) => {
         return {
           header: `${key} [${this.weightPerOption[key]}]`,

--- a/src/web/app/components/question-types/question-statistics/msq-question-statistics.component.ts
+++ b/src/web/app/components/question-types/question-statistics/msq-question-statistics.component.ts
@@ -63,7 +63,7 @@ export class MsqQuestionStatisticsComponent extends MsqQuestionStatisticsCalcula
       { header: 'Recipient Email', sortBy: SortBy.RECIPIENT_EMAIL },
       ...Object.keys(this.weightPerOption).map((key: string) => {
         return {
-          header: `${key} [${this.weightPerOption[key]}]`,
+          header: `${key} [${(this.weightPerOption[key]).toFixed(2)}]`,
           sortBy: SortBy.MSQ_OPTION_SELECTED_TIMES,
         };
       }),
@@ -84,8 +84,8 @@ export class MsqQuestionStatisticsComponent extends MsqQuestionStatisticsCalcula
             value: this.perRecipientResponses[key].responses[option],
           };
         }),
-        { value: this.perRecipientResponses[key].total },
-        { value: this.perRecipientResponses[key].average },
+        { value: (this.perRecipientResponses[key].total).toFixed(2) },
+        { value: (this.perRecipientResponses[key].average).toFixed(2) },
       ];
     });
   }

--- a/src/web/app/components/question-types/question-statistics/question-statistics-calculation/msq-question-statistics-calculation.ts
+++ b/src/web/app/components/question-types/question-statistics/question-statistics-calculation/msq-question-statistics-calculation.ts
@@ -91,19 +91,29 @@ export class MsqQuestionStatisticsCalculation
     const perRecipientResponse: Record<string, Record<string, number>> = {};
     const recipientToTeam: Record<string, string> = {};
     const recipientEmails: Record<string, string> = {};
+    const recipientNames: Record<string, string> = {};
     for (const response of this.responses) {
-      perRecipientResponse[response.recipient] = perRecipientResponse[response.recipient] || {};
-      recipientEmails[response.recipient] = recipientEmails[response.recipient] || response.recipientEmail || '';
+      if (!response.recipientEmail) {
+        continue;
+      }
+      perRecipientResponse[response.recipientEmail] = perRecipientResponse[response.recipientEmail] || {};
+      const responseEmail = response.recipientEmail;
+      recipientEmails[responseEmail] = recipientEmails[responseEmail] || responseEmail || '';
+      recipientNames[responseEmail] = recipientNames[responseEmail] || response.recipient || '';
       for (const choice of this.question.msqChoices) {
-        perRecipientResponse[response.recipient][choice] = 0;
+        perRecipientResponse[responseEmail][choice] = 0;
       }
       if (this.question.otherEnabled) {
-        perRecipientResponse[response.recipient]['Other'] = 0;
+        perRecipientResponse[responseEmail]['Other'] = 0;
       }
-      recipientToTeam[response.recipient] = response.recipientTeam;
+      recipientToTeam[responseEmail] = response.recipientTeam;
     }
     for (const response of this.responses) {
-      this.updateResponseCountPerOptionForResponse(response.responseDetails, perRecipientResponse[response.recipient]);
+      if (!response.recipientEmail) {
+        continue;
+      }
+      const email = response.recipientEmail;
+      this.updateResponseCountPerOptionForResponse(response.responseDetails, perRecipientResponse[email]);
     }
 
     for (const recipient of Object.keys(perRecipientResponse)) {
@@ -120,7 +130,7 @@ export class MsqQuestionStatisticsCalculation
       average = numOfResponsesForRecipient ? total / numOfResponsesForRecipient : 0;
 
       this.perRecipientResponses[recipient] = {
-        recipient,
+        recipient: recipientNames[recipient],
         recipientEmail: recipientEmails[recipient],
         total: +total.toFixed(5),
         average: +average.toFixed(2),

--- a/src/web/app/components/question-types/question-statistics/test-data/msqQuestionResponses.json
+++ b/src/web/app/components/question-types/question-statistics/test-data/msqQuestionResponses.json
@@ -100,7 +100,7 @@
     }
   ],
   "expectedPerRecipientResponses": {
-    "Alice": {
+    "alice@gmail.com": {
       "average": 1.5,
       "recipient": "Alice",
       "recipientEmail": "alice@gmail.com",
@@ -112,7 +112,7 @@
       },
       "total": 3
     },
-    "Bob": {
+    "bob@gmail.com": {
       "average": 1,
       "recipient": "Bob",
       "recipientEmail": "bob@gmail.com",
@@ -124,7 +124,7 @@
       },
       "total": 1
     },
-    "Charles": {
+    "charles@gmail.com": {
       "average": 0,
       "recipient": "Charles",
       "recipientEmail": "charles@gmail.com",
@@ -138,7 +138,7 @@
     }
   },
   "expectedPerRecipientResponsesWithOther": {
-    "Alice": {
+    "alice@gmail.com": {
       "average": 2,
       "recipient": "Alice",
       "recipientEmail": "alice@gmail.com",
@@ -151,7 +151,7 @@
       },
       "total": 6
     },
-    "Bob": {
+    "bob@gmail.com": {
       "average": 2.5,
       "recipient": "Bob",
       "recipientEmail": "bob@gmail.com",
@@ -164,7 +164,7 @@
       },
       "total": 5
     },
-    "Charles": {
+    "charles@gmail.com": {
       "average": 0,
       "recipient": "Charles",
       "recipientEmail": "charles@gmail.com",


### PR DESCRIPTION
Fixes #12894

**Outline of Solution**
Following the discussion in #12894, I modified both `mcq-question-statistics.component.ts` and `msq-question-statistics.component.ts` to take recipient emails into account.

I also updated the code in `msq-question-statistics.component.ts` to be more in line with the code in `mcq-question-statistics.component.ts`, calling `toFixed(2)` to format the values in the table.

In addition, I changed the tests to reflect the change from indexing students by name to indexing them by email.

I'd like to credit the authors of #12981, as I used their work to formulate my solution.



