### PR TITLE
[#11569] Relocate `app.id` and `app.version` to `gradle.properties`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-
 apply plugin: "war"
 apply plugin: "com.google.cloud.tools.appengine-appyaml"
 
@@ -256,12 +255,6 @@ task createConfigs {
     description "Sets up the project by obtaining necessary files and configurations points."
     group "Setup"
     doLast {
-        if (!project.hasProperty('appId')) {
-            project.ext.set('appId', System.getenv('GOOGLE_CLOUD_PROJECT'))
-        }
-        if (!project.hasProperty('appVersion')) {
-            project.ext.set('appVersion', System.getenv('GAE_VERSION'))
-        }
         def templatesToCopy = [
             "gradle.template.properties",
             "src/main/resources/build.template.properties",

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,4 @@
+
 apply plugin: "war"
 apply plugin: "com.google.cloud.tools.appengine-appyaml"
 
@@ -255,6 +256,12 @@ task createConfigs {
     description "Sets up the project by obtaining necessary files and configurations points."
     group "Setup"
     doLast {
+        if (!project.hasProperty('appId')) {
+            project.ext.set('appId', System.getenv('GOOGLE_CLOUD_PROJECT'))
+        }
+        if (!project.hasProperty('appVersion')) {
+            project.ext.set('appVersion', System.getenv('GAE_VERSION'))
+        }
         def templatesToCopy = [
             "gradle.template.properties",
             "src/main/resources/build.template.properties",

--- a/gradle.template.properties
+++ b/gradle.template.properties
@@ -11,12 +11,12 @@ org.gradle.daemon=false
 # This is the application ID of the app.
 # For dev server, this could be anything.
 # For staging server, this must match the name of your Google Cloud project.
-app.id = teammates-john
+app.id=${appId}
 
 # This is the version number of the app.
 # Use dashes instead of dots because GAE does not allow dots in version number.
 # e.g. app.version = 8-0-0
-app.version = 8-0-0
+app.version=${appVersion}
 
 # Use this property if you want to use a specific Cloud SDK installation.
 # If this property is not set, the latest Cloud SDK will always be used.

--- a/gradle.template.properties
+++ b/gradle.template.properties
@@ -8,6 +8,16 @@ org.gradle.daemon=false
 # e.g org.gradle.java.home=C:/Program Files/Java/jdk-11
 # org.gradle.java.home=
 
+# This is the application ID of the app.
+# For dev server, this could be anything.
+# For staging server, this must match the name of your Google Cloud project.
+app.id = teammates-john
+
+# This is the version number of the app.
+# Use dashes instead of dots because GAE does not allow dots in version number.
+# e.g. app.version = 8-0-0
+app.version = 8-0-0
+
 # Use this property if you want to use a specific Cloud SDK installation.
 # If this property is not set, the latest Cloud SDK will always be used.
 # cloud.sdk.home=/Users/visenze/Documents/google-cloud-sdk

--- a/gradle.template.properties
+++ b/gradle.template.properties
@@ -11,12 +11,12 @@ org.gradle.daemon=false
 # This is the application ID of the app.
 # For dev server, this could be anything.
 # For staging server, this must match the name of your Google Cloud project.
-app.id=${appId}
+app.id = teammates-john
 
 # This is the version number of the app.
 # Use dashes instead of dots because GAE does not allow dots in version number.
 # e.g. app.version = 8-0-0
-app.version=${appVersion}
+app.version = 8-0-0
 
 # Use this property if you want to use a specific Cloud SDK installation.
 # If this property is not set, the latest Cloud SDK will always be used.

--- a/src/main/java/teammates/common/util/Config.java
+++ b/src/main/java/teammates/common/util/Config.java
@@ -13,13 +13,13 @@ import java.util.Properties;
  */
 public final class Config {
 
-    /** The value of the "app.id" in the deployment environment. */
+    /** The value of the "app.id" in build.gradle file. */
     public static final String APP_ID;
 
     /** The value of the "app.region" in build.properties file. */
     public static final String APP_REGION;
 
-    /** The value of the "app.version" in the deployment environment. */
+    /** The value of the "app.version" in build.gradle file. */
     public static final String APP_VERSION;
 
     /** The value of the "app.frontend.url" in build.properties file. */
@@ -160,11 +160,9 @@ public final class Config {
             try (InputStream devPropStream = FileHelper.getResourceAsStream("build-dev.properties")) {
                 if (devPropStream != null) {
                     devProperties.load(devPropStream);
-                } else {
-                    log.warning("Dev environment detected but failed to load build-dev.properties file.");
                 }
             } catch (IOException e) {
-                log.warning("IOException occurred while loading build-dev.properties: " + e.getMessage());
+                    assert false;
             }
         }
 

--- a/src/main/java/teammates/common/util/Config.java
+++ b/src/main/java/teammates/common/util/Config.java
@@ -126,8 +126,6 @@ public final class Config {
     /** Indicates whether the current server is dev server. */
     public static final boolean IS_DEV_SERVER;
 
-    private static final Logger log = Logger.getLogger();
-
     static {
         Properties properties = new Properties();
         Properties gradleProperties = new Properties();

--- a/src/main/java/teammates/common/util/Config.java
+++ b/src/main/java/teammates/common/util/Config.java
@@ -13,13 +13,13 @@ import java.util.Properties;
  */
 public final class Config {
 
-    /** The value of the "app.id" in build.properties file. */
+    /** The value of the "app.id" in the deployment environment. */
     public static final String APP_ID;
 
     /** The value of the "app.region" in build.properties file. */
     public static final String APP_REGION;
 
-    /** The value of the "app.version" in build.properties file. */
+    /** The value of the "app.version" in the deployment environment. */
     public static final String APP_VERSION;
 
     /** The value of the "app.frontend.url" in build.properties file. */
@@ -149,8 +149,8 @@ public final class Config {
             } catch (IOException e) {
                 log.warning("Dev environment detected but failed to load build-dev.properties file.");
             }
-            APP_ID = getProperty(properties, devProperties, "app.id");
-            APP_VERSION = getProperty(properties, devProperties, "app.version");
+            APP_ID = System.getenv("GOOGLE_CLOUD_PROJECT");
+            APP_VERSION = System.getenv("GAE_VERSION");
         } else {
             APP_ID = appId;
             APP_VERSION = appVersion;

--- a/src/main/resources/build.template.properties
+++ b/src/main/resources/build.template.properties
@@ -4,20 +4,10 @@
 # Use '\' to escape ':' e.g., http\://google.com
 #-----------------------------------------------------------------------------
 
-# This is the application ID of the app.
-# For dev server, this could be anything.
-# For staging server, this must match the name of your Google Cloud project.
-app.id = teammates-john
-
 # This is the deployment region of the app.
 # For dev server, this could be anything.
 # For staging/production server, this must match the region of your GAE application.
 app.region=us-central1
-
-# This is the version number of the app.
-# Use dashes instead of dots because GAE does not allow dots in version number.
-# e.g. app.version = 8-0-0
-app.version = 8-0-0
 
 # This is the URL for the front-end which the user is going to access.
 # This affects all URLs sent in outbound emails.


### PR DESCRIPTION
Fixes #11569

**Outline of Solution**

Moved `app.id` and `app.version` from `build.template.properties` to `gradle.template.properties`.